### PR TITLE
Allow custom message for validation errors

### DIFF
--- a/validators/bytes_are_present.go
+++ b/validators/bytes_are_present.go
@@ -7,12 +7,21 @@ import (
 )
 
 type BytesArePresent struct {
-	Name  string
-	Field []byte
+	Name    string
+	Field   []byte
+	Message string
 }
 
+// IsValid adds an error if the field is not empty.
 func (v *BytesArePresent) IsValid(errors *validate.Errors) {
-	if len(v.Field) == 0 {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
+	if len(v.Field) > 0 {
+		return
 	}
+
+	if len(v.Message) >= 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
 }

--- a/validators/int_array_is_present.go
+++ b/validators/int_array_is_present.go
@@ -7,12 +7,21 @@ import (
 )
 
 type IntArrayIsPresent struct {
-	Name  string
-	Field []int
+	Name    string
+	Field   []int
+	Message string
 }
 
+// IsValid adds an error if the field is an empty array.
 func (v *IntArrayIsPresent) IsValid(errors *validate.Errors) {
-	if len(v.Field) == 0 {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be empty.", v.Name))
+	if len(v.Field) > 0 {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be empty.", v.Name))
 }

--- a/validators/int_is_greater_than.go
+++ b/validators/int_is_greater_than.go
@@ -10,10 +10,19 @@ type IntIsGreaterThan struct {
 	Name     string
 	Field    int
 	Compared int
+	Message  string
 }
 
+// IsValid adds an error if the field is not greater than the compared value.
 func (v *IntIsGreaterThan) IsValid(errors *validate.Errors) {
-	if !(v.Field > v.Compared) {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%d is not greater than %d.", v.Field, v.Compared))
+	if v.Field > v.Compared {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%d is not greater than %d.", v.Field, v.Compared))
 }

--- a/validators/int_is_less_than.go
+++ b/validators/int_is_less_than.go
@@ -10,10 +10,19 @@ type IntIsLessThan struct {
 	Name     string
 	Field    int
 	Compared int
+	Message  string
 }
 
+// IsValid adds an error if the field is not less than the compared value.
 func (v *IntIsLessThan) IsValid(errors *validate.Errors) {
-	if !(v.Field < v.Compared) {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%d is not less than %d.", v.Field, v.Compared))
+	if v.Field < v.Compared {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%d is not less than %d.", v.Field, v.Compared))
 }

--- a/validators/int_is_present.go
+++ b/validators/int_is_present.go
@@ -7,12 +7,21 @@ import (
 )
 
 type IntIsPresent struct {
-	Name  string
-	Field int
+	Name    string
+	Field   int
+	Message string
 }
 
+// IsValid adds an error if the field equals 0.
 func (v *IntIsPresent) IsValid(errors *validate.Errors) {
-	if v.Field == 0 {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
+	if v.Field != 0 {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
 }

--- a/validators/regex_match.go
+++ b/validators/regex_match.go
@@ -9,15 +9,23 @@ import (
 
 // RegexMatch specifies the properties needed by the validation.
 type RegexMatch struct {
-	Name  string
-	Field string
-	Expr  string
+	Name    string
+	Field   string
+	Expr    string
+	Message string
 }
 
 // IsValid performs the validation based on the regexp match.
 func (v *RegexMatch) IsValid(errors *validate.Errors) {
 	r := regexp.MustCompile(v.Expr)
-	if !r.Match([]byte(v.Field)) {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s does not match the expected format.", v.Name))
+	if r.Match([]byte(v.Field)) {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s does not match the expected format.", v.Name))
 }

--- a/validators/string_inclusion.go
+++ b/validators/string_inclusion.go
@@ -8,9 +8,10 @@ import (
 )
 
 type StringInclusion struct {
-	Name  string
-	Field string
-	List  []string
+	Name    string
+	Field   string
+	List    []string
+	Message string
 }
 
 func (v *StringInclusion) IsValid(errors *validate.Errors) {
@@ -22,6 +23,11 @@ func (v *StringInclusion) IsValid(errors *validate.Errors) {
 		}
 	}
 	if !found {
+		if len(v.Message) > 0 {
+			errors.Add(GenerateKey(v.Name), v.Message)
+			return
+		}
+
 		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s is not in the list [%s].", v.Name, strings.Join(v.List, ", ")))
 	}
 }

--- a/validators/string_inclusion.go
+++ b/validators/string_inclusion.go
@@ -14,6 +14,7 @@ type StringInclusion struct {
 	Message string
 }
 
+// IsValid adds an error if the field is not one of the allowed values.
 func (v *StringInclusion) IsValid(errors *validate.Errors) {
 	found := false
 	for _, l := range v.List {

--- a/validators/string_is_present.go
+++ b/validators/string_is_present.go
@@ -8,12 +8,21 @@ import (
 )
 
 type StringIsPresent struct {
-	Name  string
-	Field string
+	Name    string
+	Field   string
+	Message string
 }
 
+// IsValid adds an error if the field is empty.
 func (v *StringIsPresent) IsValid(errors *validate.Errors) {
-	if strings.TrimSpace(v.Field) == "" {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
+	if strings.TrimSpace(v.Field) != "" {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
 }

--- a/validators/time_after_time.go
+++ b/validators/time_after_time.go
@@ -12,10 +12,19 @@ type TimeAfterTime struct {
 	FirstTime  time.Time
 	SecondName string
 	SecondTime time.Time
+	Message    string
 }
 
+// IsValid adds an error if the FirstTime is not after the SecondTime.
 func (v *TimeAfterTime) IsValid(errors *validate.Errors) {
-	if v.FirstTime.UnixNano() < v.SecondTime.UnixNano() {
-		errors.Add(GenerateKey(v.FirstName), fmt.Sprintf("%s must be after %s.", v.FirstName, v.SecondName))
+	if v.FirstTime.UnixNano() >= v.SecondTime.UnixNano() {
+		return
 	}
+
+	if len(v.Message) == 0 {
+		errors.Add(GenerateKey(v.FirstName), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.FirstName), fmt.Sprintf("%s must be after %s.", v.FirstName, v.SecondName))
 }

--- a/validators/time_is_before_time.go
+++ b/validators/time_is_before_time.go
@@ -12,10 +12,19 @@ type TimeIsBeforeTime struct {
 	FirstTime  time.Time
 	SecondName string
 	SecondTime time.Time
+	Message    string
 }
 
+// IsValid adds an error if the FirstTime is after the SecondTime.
 func (v *TimeIsBeforeTime) IsValid(errors *validate.Errors) {
-	if v.FirstTime.UnixNano() > v.SecondTime.UnixNano() {
-		errors.Add(GenerateKey(v.FirstName), fmt.Sprintf("%s must be before %s.", v.FirstName, v.SecondName))
+	if v.FirstTime.UnixNano() <= v.SecondTime.UnixNano() {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.FirstName), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.FirstName), fmt.Sprintf("%s must be before %s.", v.FirstName, v.SecondName))
 }

--- a/validators/time_is_present.go
+++ b/validators/time_is_present.go
@@ -8,13 +8,22 @@ import (
 )
 
 type TimeIsPresent struct {
-	Name  string
-	Field time.Time
+	Name    string
+	Field   time.Time
+	Message string
 }
 
+// IsValid adds an error if the field is not a valid time.
 func (v *TimeIsPresent) IsValid(errors *validate.Errors) {
 	t := time.Time{}
-	if v.Field.UnixNano() == t.UnixNano() {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
+	if v.Field.UnixNano() != t.UnixNano() {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
 }

--- a/validators/uuid_is_present.go
+++ b/validators/uuid_is_present.go
@@ -9,13 +9,22 @@ import (
 )
 
 type UUIDIsPresent struct {
-	Name  string
-	Field uuid.UUID
+	Name    string
+	Field   uuid.UUID
+	Message string
 }
 
+// IsValid adds an error if the field is not a valid uuid.
 func (v *UUIDIsPresent) IsValid(errors *validate.Errors) {
 	s := v.Field.String()
-	if strings.TrimSpace(s) == "" || v.Field == uuid.Nil {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
+	if strings.TrimSpace(s) != "" && v.Field != uuid.Nil {
+		return
 	}
+
+	if len(v.Message) > 0 {
+		errors.Add(GenerateKey(v.Name), v.Message)
+		return
+	}
+
+	errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
 }


### PR DESCRIPTION
I think this is the first step to allow localization of error messages.
Actually, from now on, a developer can use the translator instance to translate the custom message error.