### PR TITLE
Ensure UnixNano quirks for dates that are far into the future don't break TimeAfterTime

### DIFF
--- a/validators/time_after_time.go
+++ b/validators/time_after_time.go
@@ -17,6 +17,13 @@ type TimeAfterTime struct {
 
 // IsValid adds an error if the FirstTime is not after the SecondTime.
 func (v *TimeAfterTime) IsValid(errors *validate.Errors) {
+
+	// UnixNano wraps around to negative numbers when a time is too far
+	// into the future (e.g. 260 years)
+	if v.FirstTime.Year() > v.SecondTime.Year() {
+		return 
+	}
+
 	if v.FirstTime.UnixNano() >= v.SecondTime.UnixNano() {
 		return
 	}

--- a/validators/time_after_time_test.go
+++ b/validators/time_after_time_test.go
@@ -33,4 +33,14 @@ func Test_TimeAfterTime(t *testing.T) {
 
 	r.Equal(1, errors.Count())
 	r.Equal(errors.Get("opens_at"), []string{"OpensAt must be later than Now."})
+
+	firstTime := now.AddDate(260, 0, 0)
+	v = TimeAfterTime{
+		FirstName: "Opens At", FirstTime: firstTime,
+		SecondName: "Now", SecondTime: now,
+	}
+
+	errors = validate.NewErrors()
+	v.IsValid(errors)
+	r.Equal(0, errors.Count())
 }


### PR DESCRIPTION
UnixNano appears to wrap around to negative numbers around 253 years into the future. (Maybe that depends an the MaxInt of the host system?)