### PR TITLE
Ensure UnixNano quirks for dates that are far in the past don't break TimeIsBeforeTime

### DIFF
--- a/validators/time_is_before_time.go
+++ b/validators/time_is_before_time.go
@@ -17,6 +17,9 @@ type TimeIsBeforeTime struct {
 
 // IsValid adds an error if the FirstTime is after the SecondTime.
 func (v *TimeIsBeforeTime) IsValid(errors *validate.Errors) {
+	if v.FirstTime.Year() < v.SecondTime.Year() {
+		return
+	}
 	if v.FirstTime.UnixNano() <= v.SecondTime.UnixNano() {
 		return
 	}

--- a/validators/time_is_before_time_test.go
+++ b/validators/time_is_before_time_test.go
@@ -33,4 +33,14 @@ func Test_TimeIsBeforeTime(t *testing.T) {
 
 	r.Equal(1, errors.Count())
 	r.Equal(errors.Get("opens_at"), []string{"OpensAt must be earlier than ClosesAt."})
+
+	firstTime := now.AddDate(-400, 0, 0)
+	v = TimeIsBeforeTime{
+		FirstName: "Opens At", FirstTime: firstTime,
+		SecondName: "Now", SecondTime: now,
+	}
+
+	errors = validate.NewErrors()
+	v.IsValid(errors)
+	r.Equal(0, errors.Count())
 }


### PR DESCRIPTION
UnixNano appears to wrap around to negative numbers around 320 years in the past. (Maybe that depends an the MaxInt of the host system?)